### PR TITLE
Explicitly include wolfballs.com in instance list

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 pushd ../lemmy-stats-crawler
-cargo run -- --start-instances lemmy.ml --exclude ds9.lemmy.ml,voyager.lemmy.ml,enterprise.lemmy.ml,lemmyfreedom.xyz > stats.json
+cargo run -- --start-instances lemmy.ml,wolfballs.com --exclude ds9.lemmy.ml,voyager.lemmy.ml,enterprise.lemmy.ml > stats.json
 mv stats.json ../lemmy-instance-stats
 popd


### PR DESCRIPTION
Since being blocklisted on lemmy.ml, it isnt included in the crawl anymore. Also remove lemmyfreedom.xyz from excludes as there is no Lemmy instance on that domain anymore.